### PR TITLE
fix: display correct date in chart tooltip

### DIFF
--- a/src/app/ui/Chart.tsx
+++ b/src/app/ui/Chart.tsx
@@ -8,23 +8,23 @@ import {
   ChartTooltip,
 } from '@/components/ui/chart'
 import { ObservationDto } from '@/lib/types'
-import { Area, AreaChart, CartesianGrid, LabelList, XAxis } from 'recharts'
+import { Area, AreaChart, CartesianGrid, XAxis } from 'recharts'
 
 import { formatUSD } from '@/lib/utils'
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 const CustomTooltip = ({ active, payload }: any) => {
   if (!active || !payload || !payload.length) return null
 
-  // The date comes from payload[0].payload.date (this is the x-axis value)
-  const dateStr = payload[0].payload.date
-
-  // The value comes from payload[0].value (this is the y-axis value)
+  const { year, month } = payload[0].payload
+  const dateLabel = `${MONTHS[month - 1]} ${year}`
   const value = payload[0].value
   const formattedValue = formatUSD(value, 2)
 
   return (
     <div className="bg-background rounded-lg border p-2 shadow-md">
-      <p className="text-xs font-medium">{dateStr}</p>
+      <p className="text-xs font-medium">{dateLabel}</p>
       <p className="text-xs font-semibold">{formattedValue}</p>
     </div>
   )
@@ -47,22 +47,15 @@ export function Chart({ chartData }: ChartProps) {
       <AreaChart accessibilityLayer data={chartData}>
         <CartesianGrid vertical={false} />
         <XAxis
-          dataKey="date"
+          dataKey="year"
           tickLine={false}
           tickMargin={10}
           axisLine={false}
-          tickFormatter={(dateStr) => dateStr.slice(0, 4)}
+          tickFormatter={(year) => String(year)}
         />
         <ChartTooltip content={<CustomTooltip />} />
         <ChartLegend content={<ChartLegendContent />} />
-        <Area dataKey="value" fill="var(--color-value)" radius={4}>
-          <LabelList
-            dataKey="value"
-            position="top"
-            formatter={(v: number) => formatUSD(v, 0)}
-            className="fill-foreground text-[10px] font-medium"
-          />
-        </Area>
+        <Area dataKey="value" fill="var(--color-value)" radius={4} />
       </AreaChart>
     </ChartContainer>
   )

--- a/src/app/ui/Chart.tsx
+++ b/src/app/ui/Chart.tsx
@@ -8,7 +8,7 @@ import {
   ChartTooltip,
 } from '@/components/ui/chart'
 import { ObservationDto } from '@/lib/types'
-import { Area, AreaChart, CartesianGrid, XAxis } from 'recharts'
+import { Area, AreaChart, CartesianGrid, LabelList, XAxis } from 'recharts'
 
 import { formatUSD } from '@/lib/utils'
 
@@ -55,7 +55,14 @@ export function Chart({ chartData }: ChartProps) {
         />
         <ChartTooltip content={<CustomTooltip />} />
         <ChartLegend content={<ChartLegendContent />} />
-        <Area dataKey="value" fill="var(--color-value)" radius={4} />
+        <Area dataKey="value" fill="var(--color-value)" radius={4}>
+          <LabelList
+            dataKey="value"
+            position="top"
+            formatter={(v: number) => formatUSD(v, 0)}
+            className="fill-foreground text-[10px] font-medium"
+          />
+        </Area>
       </AreaChart>
     </ChartContainer>
   )


### PR DESCRIPTION
## Summary

- The chart's `dataKey="date"` was broken — `ObservationDto` has separate `year` and `month` integer fields, not a `date` string, so the tooltip was silently showing nothing for the date
- Fixed the tooltip to derive a formatted `"Jan 1975"` date label from the actual `year` and `month` fields
- Updated the X-axis `dataKey` to use `year` directly

## Test plan

- [x] Enter an amount and year, click Calculate
- [x] Hover over the chart area and confirm the tooltip shows a formatted month-year (e.g. "Jan 1975") alongside the inflation-adjusted value
- [x] Confirm the X-axis tick labels display correctly as years
- [x] Verify no visual overlay or rendering artifacts on the chart

https://claude.ai/code/session_013YLKEkjCEX2zMjgxiFevsg