### PR TITLE
fix(ui): open GitHub link in a new tab

### DIFF
--- a/src/app/ui/GitHubLink.tsx
+++ b/src/app/ui/GitHubLink.tsx
@@ -16,7 +16,7 @@ export function GitHubLink({ href }: GitHubLinkProps) {
     <Tooltip>
       <TooltipTrigger asChild>
         <Button asChild variant="ghost">
-          <Link href={href}>
+          <Link href={href} target="_blank" rel="noopener noreferrer">
             <SiGithub className="size-5 sm:size-4" />
           </Link>
         </Button>


### PR DESCRIPTION
## Summary
- Added `target="_blank"` and `rel="noopener noreferrer"` to the GitHub icon link in the app header so it opens in a new tab.

## Test plan
- [x] Click the GitHub icon in the app header — it should open the repo in a new browser tab rather than navigating away.

Closes #51

https://claude.ai/code/session_01TzpcJFUtns3SvpQFZq4nxW