### PR TITLE
feat(ci): dry run auto-merge when not on main

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,11 +23,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.ref != 'refs/heads/main' && 'true' || 'false' }}
         run: |
           set -uo pipefail
           # GitHub Actions runs this with `bash -e` by default; disable errexit
           # so a single failing API call doesn't abort the whole loop.
           set +e
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::Dry run mode — no PRs will be merged (branch is not main)"
+          fi
 
           prs=$(gh pr list \
             --repo "$REPO" \
@@ -89,9 +94,13 @@ jobs:
 
             case "$state" in
               success)
-                echo "Merging PR #$number"
-                gh pr merge --repo "$REPO" --merge "$number" \
-                  || echo "Merge failed for PR #$number"
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "Would merge PR #$number (dry run)"
+                else
+                  echo "Merging PR #$number"
+                  gh pr merge --repo "$REPO" --merge "$number" \
+                    || echo "Merge failed for PR #$number"
+                fi
                 ;;
               failure|error)
                 echo "Deployment failed — leaving open for manual review"


### PR DESCRIPTION
## Summary
- Adds a `DRY_RUN` env var set to `true` whenever the workflow runs on any branch other than `main`
- In dry run mode, a notice is logged at the top of the run and eligible PRs print "Would merge PR #N" instead of being merged
- The scheduled run always fires on `main`, so production behavior is unchanged; `workflow_dispatch` from a feature branch is now safe to use for testing

## Test plan
- [x] Trigger via `workflow_dispatch` from this branch — confirm the notice appears and no PRs are merged
- [ ] After merging to `main`, trigger again — confirm PRs are actually merged

https://claude.ai/code/session_01TzpcJFUtns3SvpQFZq4nxW