### PR TITLE
feat(ui): persist chosen inflation index via cookie

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,68 +1,21 @@
-'use client'
-
 import PageWrapper from '@/components/PageWrapper'
-import { Body, H1, H2 } from '@/components/typography'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { ObservationDto, CalculationResult } from '@/lib/types'
-import { formatUSD } from '@/lib/utils'
-import { useState } from 'react'
-import { Chart } from './ui/Chart'
-import { InputForm } from './ui/InputForm'
+import { H1 } from '@/components/typography'
+import { InflationMeasure } from '@/lib/types'
+import { cookies } from 'next/headers'
+import { CalculatorView } from './ui/CalculatorView'
 
-export default function HomePage() {
-  const [inputDollars, setInputDollars] = useState<number>()
-  const [inputYear, setInputYear] = useState<number>()
-  const [outputDollars, setOutputDollars] = useState<number | null>()
-  const [observations, setObservations] = useState<ObservationDto[]>([])
+const DEFAULT_MEASURE: InflationMeasure = 'CPI'
 
-  function handleSubmit(outputs: CalculationResult) {
-    setInputDollars(outputs.startingAmount)
-    setInputYear(outputs.year)
-    setObservations(outputs.observations)
-    setOutputDollars(
-      outputs.observations[outputs.observations.length - 1].value
-    )
-  }
+export default async function HomePage() {
+  const cookieStore = await cookies()
+  const stored = cookieStore.get('inflationMeasure')?.value
+  const initialMeasure: InflationMeasure =
+    stored === 'CPI' || stored === 'PCE' ? stored : DEFAULT_MEASURE
 
   return (
     <PageWrapper>
       <H1>How much is that in today&apos;s dollars?</H1>
-      <H2>Inputs</H2>
-      <InputForm handleSubmitInParent={handleSubmit} />
-      <H2>Outputs</H2>
-      <Tooltip>
-        <TooltipTrigger className="mr-auto flex flex-row items-center gap-2">
-          <div className="rounded-lg border px-6 py-4 shadow-xs">
-            <Body className="text-xl font-semibold">
-              {outputDollars ? formatUSD(outputDollars) : '$ -'}
-            </Body>
-          </div>
-          <Body>{"in today's dollars"}</Body>
-        </TooltipTrigger>
-        {outputDollars && inputDollars && (
-          <TooltipContent>
-            <Body>
-              <span className="underline underline-offset-2">
-                {formatUSD(inputDollars)}
-              </span>{' '}
-              in{' '}
-              <span className="underline underline-offset-2">{inputYear}</span>{' '}
-              would be worth{' '}
-              <span className="underline underline-offset-2">
-                {formatUSD(outputDollars)}
-              </span>{' '}
-              in today&apos;s dollars.
-            </Body>
-          </TooltipContent>
-        )}
-      </Tooltip>
-      <div className="flex items-center justify-center rounded-lg border shadow-xs">
-        <Chart chartData={observations} />
-      </div>
+      <CalculatorView initialMeasure={initialMeasure} />
     </PageWrapper>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import PageWrapper from '@/components/PageWrapper'
 import { H1 } from '@/components/typography'
+import { INFLATION_MEASURE_COOKIE } from '@/lib/constants'
 import { InflationMeasure } from '@/lib/types'
 import { cookies } from 'next/headers'
 import { CalculatorView } from './ui/CalculatorView'
@@ -8,7 +9,7 @@ const DEFAULT_MEASURE: InflationMeasure = 'CPI'
 
 export default async function HomePage() {
   const cookieStore = await cookies()
-  const stored = cookieStore.get('inflationMeasure')?.value
+  const stored = cookieStore.get(INFLATION_MEASURE_COOKIE)?.value
   const initialMeasure: InflationMeasure =
     stored === 'CPI' || stored === 'PCE' ? stored : DEFAULT_MEASURE
 

--- a/src/app/ui/CalculatorView.tsx
+++ b/src/app/ui/CalculatorView.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { Body, H2 } from '@/components/typography'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
+  CalculationResult,
+  InflationMeasure,
+  ObservationDto,
+} from '@/lib/types'
+import { formatUSD } from '@/lib/utils'
+import { useState } from 'react'
+import { Chart } from './Chart'
+import { InputForm } from './InputForm'
+
+interface CalculatorViewProps {
+  initialMeasure: InflationMeasure
+}
+
+export function CalculatorView({ initialMeasure }: CalculatorViewProps) {
+  // HOOKS
+  const [inputDollars, setInputDollars] = useState<number>()
+  const [inputYear, setInputYear] = useState<number>()
+  const [outputDollars, setOutputDollars] = useState<number | null>()
+  const [observations, setObservations] = useState<ObservationDto[]>([])
+
+  // EVENT HANDLERS
+  function handleSubmit(outputs: CalculationResult) {
+    setInputDollars(outputs.startingAmount)
+    setInputYear(outputs.year)
+    setObservations(outputs.observations)
+    setOutputDollars(
+      outputs.observations[outputs.observations.length - 1].value
+    )
+  }
+
+  return (
+    <>
+      <H2>Inputs</H2>
+      <InputForm
+        initialMeasure={initialMeasure}
+        handleSubmitInParent={handleSubmit}
+      />
+      <H2>Outputs</H2>
+      <Tooltip>
+        <TooltipTrigger className="mr-auto flex flex-row items-center gap-2">
+          <div className="rounded-lg border px-6 py-4 shadow-xs">
+            <Body className="text-xl font-semibold">
+              {outputDollars ? formatUSD(outputDollars) : '$ -'}
+            </Body>
+          </div>
+          <Body>{"in today's dollars"}</Body>
+        </TooltipTrigger>
+        {outputDollars && inputDollars && (
+          <TooltipContent>
+            <Body>
+              <span className="underline underline-offset-2">
+                {formatUSD(inputDollars)}
+              </span>{' '}
+              in{' '}
+              <span className="underline underline-offset-2">{inputYear}</span>{' '}
+              would be worth{' '}
+              <span className="underline underline-offset-2">
+                {formatUSD(outputDollars)}
+              </span>{' '}
+              in today&apos;s dollars.
+            </Body>
+          </TooltipContent>
+        )}
+      </Tooltip>
+      <div className="flex items-center justify-center rounded-lg border shadow-xs">
+        <Chart chartData={observations} />
+      </div>
+    </>
+  )
+}

--- a/src/app/ui/InputForm.tsx
+++ b/src/app/ui/InputForm.tsx
@@ -20,30 +20,34 @@ import {
   inputsSchema,
 } from '@/lib/types'
 import { zodResolver } from '@hookform/resolvers/zod'
-import type { Resolver } from 'react-hook-form'
 import { PlayIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import type { Resolver } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 
-const STORAGE_KEY = 'inflationMeasure'
-const DEFAULT_MEASURE: InflationMeasure = 'CPI'
+const COOKIE_NAME = 'inflationMeasure'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365 // 1 year
 
-function getStoredMeasure(): InflationMeasure {
-  if (typeof window === 'undefined') return DEFAULT_MEASURE
-  const stored = localStorage.getItem(STORAGE_KEY)
-  return stored === 'CPI' || stored === 'PCE' ? stored : DEFAULT_MEASURE
+function setMeasureCookie(measure: InflationMeasure) {
+  document.cookie = `${COOKIE_NAME}=${measure}; max-age=${COOKIE_MAX_AGE}; path=/; samesite=lax`
 }
 
 interface InputFormProps {
+  initialMeasure: InflationMeasure
   handleSubmitInParent: (outputs: CalculationResult) => void
 }
 
-export function InputForm({ handleSubmitInParent }: InputFormProps) {
+export function InputForm({
+  initialMeasure,
+  handleSubmitInParent,
+}: InputFormProps) {
   const form = useForm<CalculationInputs>({
-    resolver: zodResolver(inputsSchema) as unknown as Resolver<CalculationInputs>,
+    resolver: zodResolver(
+      inputsSchema
+    ) as unknown as Resolver<CalculationInputs>,
     defaultValues: {
-      inflationMeasure: DEFAULT_MEASURE,
+      inflationMeasure: initialMeasure,
       startAmount: 100,
       startYear: 1975,
     },
@@ -52,18 +56,12 @@ export function InputForm({ handleSubmitInParent }: InputFormProps) {
   const [isLoading, setIsLoading] = useState(false)
 
   // HOOKS
-  useEffect(() => {
-    const stored = getStoredMeasure()
-    if (stored !== DEFAULT_MEASURE) {
-      form.setValue('inflationMeasure', stored)
-    }
-  }, [form])
-
   const watchedMeasure = form.watch('inflationMeasure')
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, watchedMeasure)
+    setMeasureCookie(watchedMeasure)
   }, [watchedMeasure])
 
+  // EVENT HANDLERS
   async function onSubmit(values: CalculationInputs) {
     setIsLoading(true)
     try {

--- a/src/app/ui/InputForm.tsx
+++ b/src/app/ui/InputForm.tsx
@@ -13,13 +13,27 @@ import {
 import { Input } from '@/components/ui/input'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { getInflationAdjustedAmounts } from '@/lib/actions/calculate'
-import { CalculationInputs, CalculationResult, inputsSchema } from '@/lib/types'
+import {
+  CalculationInputs,
+  CalculationResult,
+  InflationMeasure,
+  inputsSchema,
+} from '@/lib/types'
 import { zodResolver } from '@hookform/resolvers/zod'
 import type { Resolver } from 'react-hook-form'
 import { PlayIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
+
+const STORAGE_KEY = 'inflationMeasure'
+const DEFAULT_MEASURE: InflationMeasure = 'CPI'
+
+function getStoredMeasure(): InflationMeasure {
+  if (typeof window === 'undefined') return DEFAULT_MEASURE
+  const stored = localStorage.getItem(STORAGE_KEY)
+  return stored === 'CPI' || stored === 'PCE' ? stored : DEFAULT_MEASURE
+}
 
 interface InputFormProps {
   handleSubmitInParent: (outputs: CalculationResult) => void
@@ -29,13 +43,26 @@ export function InputForm({ handleSubmitInParent }: InputFormProps) {
   const form = useForm<CalculationInputs>({
     resolver: zodResolver(inputsSchema) as unknown as Resolver<CalculationInputs>,
     defaultValues: {
-      inflationMeasure: 'CPI',
+      inflationMeasure: DEFAULT_MEASURE,
       startAmount: 100,
       startYear: 1975,
     },
   })
 
   const [isLoading, setIsLoading] = useState(false)
+
+  // HOOKS
+  useEffect(() => {
+    const stored = getStoredMeasure()
+    if (stored !== DEFAULT_MEASURE) {
+      form.setValue('inflationMeasure', stored)
+    }
+  }, [form])
+
+  const watchedMeasure = form.watch('inflationMeasure')
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, watchedMeasure)
+  }, [watchedMeasure])
 
   async function onSubmit(values: CalculationInputs) {
     setIsLoading(true)
@@ -72,7 +99,7 @@ export function InputForm({ handleSubmitInParent }: InputFormProps) {
               <FormControl>
                 <RadioGroup
                   onValueChange={field.onChange}
-                  defaultValue={field.value}
+                  value={field.value}
                   className="flex flex-row"
                 >
                   <FormItem className="flex items-center gap-2">

--- a/src/app/ui/InputForm.tsx
+++ b/src/app/ui/InputForm.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { getInflationAdjustedAmounts } from '@/lib/actions/calculate'
+import { INFLATION_MEASURE_COOKIE } from '@/lib/constants'
 import {
   CalculationInputs,
   CalculationResult,
@@ -26,11 +27,10 @@ import type { Resolver } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 
-const COOKIE_NAME = 'inflationMeasure'
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365 // 1 year
 
 function setMeasureCookie(measure: InflationMeasure) {
-  document.cookie = `${COOKIE_NAME}=${measure}; max-age=${COOKIE_MAX_AGE}; path=/; samesite=lax`
+  document.cookie = `${INFLATION_MEASURE_COOKIE}=${measure}; max-age=${COOKIE_MAX_AGE}; path=/; samesite=lax`
 }
 
 interface InputFormProps {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const INFLATION_MEASURE_COOKIE = 'inflationMeasure'


### PR DESCRIPTION
## Summary

- Converts `page.tsx` to a Server Component that reads an `inflationMeasure` cookie and passes the value down as `initialMeasure`
- Extracts all client-side state and interactivity into `CalculatorView` (new `'use client'` component); `PageWrapper` and `H1` remain server-rendered
- `InputForm` accepts `initialMeasure` as a prop and writes to the cookie on every change via `document.cookie`
- Cookie name is defined once in `src/lib/constants.ts` and imported by both the server and client

Using a cookie (rather than localStorage) means the server renders the correct measure from the start — no post-hydration flicker.

## Test plan

- [x] Select PCE, reload the page — PCE should be pre-selected with no flicker
- [x] Select CPI, reload the page — CPI should be pre-selected with no flicker
- [x] Open the app with no cookie set — CPI should be selected by default

Closes #68